### PR TITLE
Update to fix non saving of text

### DIFF
--- a/comments.qml
+++ b/comments.qml
@@ -90,7 +90,6 @@ MuseScore {
                     width : window.width,
                     height : window.height
                 }
-                curScore.setMetaTag("comments", abcText.text)
                 settings.metrics =  JSON.stringify(metrics);
             }
             Qt.quit()

--- a/comments.qml
+++ b/comments.qml
@@ -61,6 +61,8 @@ MuseScore {
             Keys.onPressed : {
                 if (event.key == Qt.Key_Escape) {
                     window.close();
+                } else {
+                   curScore.setMetaTag("comments", abcText.text)
                 }
             }
             Component.onCompleted : {


### PR DESCRIPTION
I don't know about the duplicate window though.  Do I need to do something specific for Mac's?

There will also be a problem if a user changes score without closing the window first, the text will not be changed.  This should be fixable, I am happy to look at it if you wish.