### PR TITLE
Mods

### DIFF
--- a/comments.qml
+++ b/comments.qml
@@ -8,7 +8,7 @@ MuseScore {
     menuPath : "Plugins.Comments"
     version : "2.0"
     description : qsTr("This plugin adds comments to your score")
-    //Removed plugin type as it's not really a dialog anymore and is causing two windows to be present on MAC
+    //SL Removed plugin type as it's not really a dialog anymore and is causing two windows to be present on MAC
     //pluginType : "Dialog"
     //requiresScore: true // needs MuseScore > 2.0.3
 

--- a/comments.qml
+++ b/comments.qml
@@ -25,8 +25,10 @@ MuseScore {
         width : 400;
         height : 300;
         visible : false
+	//SL Added variable to hold the score current to this plugin
         property var score : curScore
-		title : {"MuseScore : " + curScore.name;}
+	//SL Added title so it is obvious which score the text will be added to
+        title : {"MuseScore : " + curScore.name;}
 
         Settings {
             id : settings
@@ -47,7 +49,6 @@ MuseScore {
 
         TextArea {
             id : abcText
-
             anchors.top : textLabel.bottom
             anchors.left : window.left
             anchors.right : window.right
@@ -61,6 +62,7 @@ MuseScore {
             focus : true
             wrapMode : TextEdit.WrapAnywhere
             textFormat : TextEdit.PlainText
+	    //SL Changed from onPressed as in some circumstances the last key pressed was lost.
             Keys.onReleased : {
                 if (event.key == Qt.Key_Escape) {
                     window.close();
@@ -98,11 +100,15 @@ MuseScore {
             }
             Qt.quit()
         }
+	//Added onActiveChanged so we can test if the score has been changed.
         onActiveChanged : {
             if (active) {
                 if (score != curScore) {
-					window.title = "MuseScore : " + curScore.name;
+		    //Add new scorename to title
+                    window.title = "MuseScore : " + curScore.name;
+		    //Update the new score text
                     abcText.text = curScore.metaTag("comments");
+		    //Now working on the new score
                     score = curScore;
                 }
             }

--- a/comments.qml
+++ b/comments.qml
@@ -8,7 +8,7 @@ MuseScore {
     menuPath : "Plugins.Comments"
     version : "2.0"
     description : qsTr("This plugin adds comments to your score")
-    pluginType : "dialog"
+    pluginType : "Dialog"
     //requiresScore: true // needs MuseScore > 2.0.3
 
 
@@ -24,10 +24,12 @@ MuseScore {
         id : window
         width : 400;
         height : 300;
-        visible : false;
-		
+        visible : false
+        property var score : curScore
+        title : {"MuseScore : " + curScore.name;}
+
         Settings {
-            id: settings
+            id : settings
             category : "pluginSettings"
             property string metrics : ""
         }
@@ -45,6 +47,7 @@ MuseScore {
 
         TextArea {
             id : abcText
+
             anchors.top : textLabel.bottom
             anchors.left : window.left
             anchors.right : window.right
@@ -58,11 +61,11 @@ MuseScore {
             focus : true
             wrapMode : TextEdit.WrapAnywhere
             textFormat : TextEdit.PlainText
-            Keys.onPressed : {
+            Keys.onReleased : {
                 if (event.key == Qt.Key_Escape) {
                     window.close();
                 } else {
-                   curScore.setMetaTag("comments", abcText.text)
+                    curScore.setMetaTag("comments", abcText.text)
                 }
             }
             Component.onCompleted : {
@@ -90,9 +93,19 @@ MuseScore {
                     width : window.width,
                     height : window.height
                 }
-                settings.metrics =  JSON.stringify(metrics);
+                curScore.setMetaTag("comments", abcText.text)
+                settings.metrics = JSON.stringify(metrics);
             }
             Qt.quit()
+        }
+        onActiveChanged : {
+            if (active) {
+                if (score != curScore) {
+                    window.title = "MuseScore : " + curScore.name;
+                    abcText.text = curScore.metaTag("comments");
+                    score = curScore;
+                }
+            }
         }
     }
 }

--- a/comments.qml
+++ b/comments.qml
@@ -8,6 +8,7 @@ MuseScore {
     menuPath : "Plugins.Comments"
     version : "2.0"
     description : qsTr("This plugin adds comments to your score")
+    //Removed plugin type as it's not really a dialog anymore and is causing two windows to be present on MAC
     //pluginType : "Dialog"
     //requiresScore: true // needs MuseScore > 2.0.3
 

--- a/comments.qml
+++ b/comments.qml
@@ -8,7 +8,7 @@ MuseScore {
     menuPath : "Plugins.Comments"
     version : "2.0"
     description : qsTr("This plugin adds comments to your score")
-    pluginType : "Dialog"
+    //pluginType : "Dialog"
     //requiresScore: true // needs MuseScore > 2.0.3
 
 
@@ -26,7 +26,7 @@ MuseScore {
         height : 300;
         visible : false
         property var score : curScore
-        title : {"MuseScore : " + curScore.name;}
+		title : {"MuseScore : " + curScore.name;}
 
         Settings {
             id : settings
@@ -101,7 +101,7 @@ MuseScore {
         onActiveChanged : {
             if (active) {
                 if (score != curScore) {
-                    window.title = "MuseScore : " + curScore.name;
+					window.title = "MuseScore : " + curScore.name;
                     abcText.text = curScore.metaTag("comments");
                     score = curScore;
                 }


### PR DESCRIPTION
Removed pluginType : "dialog" which seems to have been showing two windows on MAC, tested on an old one and no longer displays two.

Added property score to window object to record the score the plugin is working on.
Added title to window to make it obvious which score the text belongs to
Changed from Keys.onPressed to Keys.onReleased as in some circumstances the last keypress was lost.
Added onActiveChanged to window object to check if the score has changed,  If it has, the text and title are changed as appropriate.